### PR TITLE
Fix the status for zip file

### DIFF
--- a/lib/handlers.ml
+++ b/lib/handlers.ml
@@ -122,7 +122,7 @@ let pp_bp_config ~binary fmt () =
   (import-prelude false)@\n\
   @[<v 2>(prover@ \
     @[<v 2>(name ae-read-status)@ \
-      @[<v 2>(cmd \"rg --search-zip :status $file\")@ \
+      @[<v 2>(cmd \"zgrep :status $file\")@ \
         @[<v 2>(unknown \":status unknown\")@ \
           @[<v 2>(unknown \"\")@ \
             @[<v 2>(sat \":status sat\")@ \


### PR DESCRIPTION
`ripgrep` does not support searching in zip file actually. I replaced it by `zgrep`. Should work with common files also.